### PR TITLE
Follow the same semantics as webapp for "plugins"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,49 @@ Adapted from https://github.com/webpack-contrib/exports-loader.
 # Configuration
 
 ```
-loaders: [{
-    test: /\.js[x]?$/,
-    loader: `autoload-plugins-loader?path/to/foo.js`,
-}],
+module: {
+    rules: [
+        {
+            test: /\.js[x]?$/,
+            use: [
+                {
+                    loader: 'autoload-plugins-loader',
+                    options: {
+                        moduleToPluginsMap: {
+                            [path.resolve(__dirname, 'fixtures/dep-a.js')]: [
+                                path.resolve(__dirname, 'fixtures/dep-a-plugin-1.js'),
+                                path.resolve(__dirname, 'fixtures/dep-a-plugin-2.js'),
+                            ],
+                            [path.resolve(__dirname, 'fixtures/dep-b.js')]: [
+                                path.resolve(__dirname, 'fixtures/dep-b-plugin.js'),
+                            ],
+                        },
+                    },
+                },
+            ],
+        },
+        {
+            test: /\.handlebars$/,
+            use: [
+                {
+                    loader: 'autoload-plugins-loader',
+                    options: {
+                        moduleToPluginsMap: {
+                            [require.resolve('handlebars/runtime')]: [
+                                path.resolve(__dirname, 'fixtures/handlebars-extras.js'),
+                            ],
+                        },
+                    },
+                },
+                {
+                    loader: 'handlebars-loader',
+                },
+            ],
+        },
+    ],
+},
 ```
 
-Paths are relative to `__dirname`.
+Notes:
+- all paths must be absolute paths.
+- must be run after transpiling `import` statements to `require`s.

--- a/index.js
+++ b/index.js
@@ -10,41 +10,69 @@ const path = require("path");
 const loaderUtils = require("loader-utils");
 const SourceNode = require("source-map").SourceNode;
 const SourceMapConsumer = require("source-map").SourceMapConsumer;
-const FOOTER = "/*** REQUIRES FROM autoload-plugins-loader ***/\n";
+const matchAll = require('match-all');
+const promisify = require("util").promisify;
+
+const FOOTER = "/*** REQUIRES FROM autoload-modules-loader ***/\n";
+
+const REQUIRE_RE = /\brequire\s*\(\s*[\'"]([^\'"]*)[\'"]\s*\)/g;
 
 module.exports = function(content, sourceMap) {
-    const resourcePath = this.resourcePath;
-
     if (this.cacheable) {
         this.cacheable();
     }
 
-    const query = loaderUtils.getOptions(this) || {};
-    const requires = [];
-    const keys = Object.keys(query);
+    const resolve = promisify(this.resolve);
 
-    if (keys.length == 1 && typeof query[keys[0]] == "boolean") {
-        const mod = keys[0];
-        const modPath = path.resolve(__dirname, mod);
-        requires.push(`require("${modPath}");   // ${mod}`);
-    } else {
-        keys.forEach(function(name) {
-            const mod = name;
-            const modPath = path.resolve(__dirname, mod);
-            requires.push(`require("${modPath}");   // ${mod}`);
-        });
-    }
+    // Find all 'require' statements
+    const reqs = matchAll(content, REQUIRE_RE).toArray();
+    const reqsToAdd = [];
 
-    if (sourceMap) {
-        const currentRequest = loaderUtils.getCurrentRequest(this);
-        const node = SourceNode.fromStringWithSourceMap(content, new SourceMapConsumer(sourceMap));
-        node.add("\n\n" + FOOTER + requires.join("\n"));
-        const result = node.toStringWithSourceMap({
-            file: currentRequest
-        });
-        this.callback(null, result.code, result.map.toJSON());
-        return;
-    }
+    // Use async mode b/c we calling this.resolve() is async
+    const callback = this.async();
 
-    return content + "\n\n" + FOOTER + requires.join("\n");
+    Promise.all(reqs.map(req => resolve(this.context, req))).then(resolvedReqs => {
+        const requires = [];
+        const {moduleToPluginsMap} = this.query;
+
+        for (const resolvedReq of resolvedReqs) {
+            if (resolvedReq in moduleToPluginsMap) {
+                // If the absolute path for any of those require statements
+                // matches a key in moduleToPluginsMap, add 'require' calls
+                // for each of the "plugins" to the list of requires we're
+                // going to append to the file being loaded.
+                const plugins = moduleToPluginsMap[resolvedReq];
+                for (const plugin of plugins) {
+                    const relPath = path.relative(path.dirname(this.resource), plugin);
+                    requires.push(`require("${plugin}"); // ${relPath}`);
+                }
+            }
+        }
+
+        const error = null;
+
+        // Append 'require' calls to the file if there are any.
+        if (sourceMap) {
+            if (requires.length > 0) {
+                const currentRequest = loaderUtils.getCurrentRequest(this);
+                const node = SourceNode.fromStringWithSourceMap(
+                    content, new SourceMapConsumer(sourceMap));
+                node.add("\n\n" + FOOTER + requires.join("\n"));
+                const result = node.toStringWithSourceMap({
+                    file: currentRequest
+                });
+                callback(error, result.code, result.map.toJSON());
+            } else {
+                callback(error, content, sourceMap);
+            }
+        } else {
+            if (requires.length > 0) {
+                callback(error, content + "\n\n" + FOOTER + requires.join("\n"));
+            } else {
+                callback(error, content);
+            }
+        }
+    });
+
+    return undefined;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1355,6 +1355,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fastparse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+      "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
+      "dev": true
+    },
     "fb-watchman": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
@@ -2559,6 +2565,37 @@
         }
       }
     },
+    "handlebars-loader": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/handlebars-loader/-/handlebars-loader-1.6.0.tgz",
+      "integrity": "sha512-FsM1ALql8+RNJuTgD1qPrVT8GpB209hPUKml/uIoR6aJIoeoLB+l/jt8xBnpfzN74aaQ9kMXaZajhIE6PNHusg==",
+      "dev": true,
+      "requires": {
+        "async": "0.2.10",
+        "fastparse": "1.1.1",
+        "loader-utils": "1.0.4",
+        "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.4.tgz",
+          "integrity": "sha1-E/Vhl/FSOjBYkSSLTHJEVAhIQmw=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        }
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -3552,6 +3589,11 @@
       "requires": {
         "tmpl": "1.0.4"
       }
+    },
+    "match-all": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/match-all/-/match-all-1.2.4.tgz",
+      "integrity": "sha512-V/fHK8ld4mxVLn7vOlyp8wH6EqVD4+wLUrdtbuFNzttgpZ/JAjaSVLqVd66dlKCdGcN1zEyEkERTremiaTve9g=="
     },
     "md5.js": {
       "version": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
   "license": "MIT",
   "dependencies": {
     "loader-utils": "^1.1.0",
+    "match-all": "^1.2.4",
     "source-map": "^0.6.1"
   },
   "devDependencies": {
+    "handlebars-loader": "^1.6.0",
     "jest": "^21.2.1",
     "memory-fs": "^0.4.1",
     "webpack": "^3.10.0"

--- a/test/fixtures/bar.js
+++ b/test/fixtures/bar.js
@@ -1,3 +1,2 @@
-const bar = "bar";
-
-module.exports = "bar";
+const depB = require("./dep-b");
+const depC = require("./dep-c");

--- a/test/fixtures/baz.js
+++ b/test/fixtures/baz.js
@@ -1,3 +1,1 @@
-const baz = "baz";
-
-module.exports = baz;
+const depC = require("./dep-c");

--- a/test/fixtures/dep-a-plugin-1.js
+++ b/test/fixtures/dep-a-plugin-1.js
@@ -1,0 +1,1 @@
+// plugin-1 for dep

--- a/test/fixtures/dep-a-plugin-2.js
+++ b/test/fixtures/dep-a-plugin-2.js
@@ -1,0 +1,1 @@
+// plugin-2 for dep

--- a/test/fixtures/dep-a.js
+++ b/test/fixtures/dep-a.js
@@ -1,0 +1,1 @@
+// Dependency with multiple plugins

--- a/test/fixtures/dep-b.js
+++ b/test/fixtures/dep-b.js
@@ -1,0 +1,1 @@
+// Dependency a single plugin

--- a/test/fixtures/dep-c.js
+++ b/test/fixtures/dep-c.js
@@ -1,0 +1,1 @@
+// Dependency w/o plugins

--- a/test/fixtures/foo.js
+++ b/test/fixtures/foo.js
@@ -1,3 +1,3 @@
-const foo = "foo";
-
-module.exports = foo;
+const depA = require("./dep-a");
+const depB = require("./dep-b");
+const depC = require("./dep-c");

--- a/test/fixtures/handlebars-extras.js
+++ b/test/fixtures/handlebars-extras.js
@@ -1,0 +1,3 @@
+const Handlebars = require("handlebars/runtime");
+
+// register helpers

--- a/test/fixtures/qux.js
+++ b/test/fixtures/qux.js
@@ -1,0 +1,2 @@
+const template1 = require('./template-1.handlebars');
+const Handlebars = require("handlebars/runtime");

--- a/test/fixtures/template-1.handlebars
+++ b/test/fixtures/template-1.handlebars
@@ -1,0 +1,3 @@
+<div>
+    Hello, world!
+</div>

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -13,23 +13,56 @@ function compile(compiler) {
     });
 }
 
-function createCompiler(plugins) {
+function createCompiler(entry) {
     return webpack({
         bail: true,
         cache: false,
-        entry: {
-            foo: path.resolve(__dirname, 'fixtures/foo.js'),
-        },
+        entry: entry,
         output: {
             path: `/dist`,
             filename: '[name].js',
             chunkFilename: '[name].js',
         },
         module: {
-            loaders: [{
-                test: /\.js[x]?$/,
-                loader: `autoload-plugins-loader?${plugins.join(',')}`,
-            }],
+            rules: [
+                {
+                    test: /\.js[x]?$/,
+                    use: [
+                        {
+                            loader: 'autoload-plugins-loader',
+                            options: {
+                                moduleToPluginsMap: {
+                                    [path.resolve(__dirname, 'fixtures/dep-a.js')]: [
+                                        path.resolve(__dirname, 'fixtures/dep-a-plugin-1.js'),
+                                        path.resolve(__dirname, 'fixtures/dep-a-plugin-2.js'),
+                                    ],
+                                    [path.resolve(__dirname, 'fixtures/dep-b.js')]: [
+                                        path.resolve(__dirname, 'fixtures/dep-b-plugin.js'),
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                },
+                {
+                    test: /\.handlebars$/,
+                    use: [
+                        {
+                            loader: 'autoload-plugins-loader',
+                            options: {
+                                moduleToPluginsMap: {
+                                    [require.resolve('handlebars/runtime')]: [
+                                        path.resolve(__dirname, 'fixtures/handlebars-extras.js'),
+                                    ],
+                                },
+                            },
+                        },
+                        {
+                            loader: 'handlebars-loader',
+                        },
+                    ],
+                },
+            ],
         },
         resolveLoader: {
             alias: {
@@ -40,32 +73,62 @@ function createCompiler(plugins) {
 }
 
 describe('autoloader-plugins-loader', () => {
-    it('should work with a single plugin', () => {
-        const compiler = createCompiler(['test/fixtures/bar.js']);
+    it('should work with multiple modules that have plugins',  () => {
+        const compiler = createCompiler({
+            foo: path.resolve(__dirname, 'fixtures/foo.js'),
+        });
         const fs = new MemoryFileSystem();
         compiler.outputFileSystem = fs;
-
         return compile(compiler).then(() => {
             const foo = fs.readFileSync("/dist/foo.js").toString();
-            expect(foo).toContain(
-                '/*** REQUIRES FROM autoload-plugins-loader ***/');
-            expect(foo).toContain('__webpack_require__(0);   // test/fixtures/bar.js');
+
+            expect(foo).toContain('/*** REQUIRES FROM autoload-modules-loader ***/');
+            expect(foo).toContain('__webpack_require__(4); // dep-a-plugin-1.js');
+            expect(foo).toContain('__webpack_require__(5); // dep-a-plugin-2.js');
+            expect(foo).toContain('__webpack_require__(6); // dep-b-plugin.js');
         });
     });
 
-    it('should work with multiple plugins', () => {
-        const compiler = createCompiler(
-            ['test/fixtures/bar.js', 'test/fixtures/baz.js']);
+    it('should work with a single module with a plugin',  () => {
+        const compiler = createCompiler({
+            bar: path.resolve(__dirname, 'fixtures/bar.js'),
+        });
         const fs = new MemoryFileSystem();
         compiler.outputFileSystem = fs;
-
         return compile(compiler).then(() => {
-            const foo = fs.readFileSync("/dist/foo.js").toString();
-            expect(foo).toContain(
-                '/*** REQUIRES FROM autoload-plugins-loader ***/');
-            expect(foo).toContain('__webpack_require__(0);   // test/fixtures/bar.js');
-            expect(foo).toContain('__webpack_require__(1);   // test/fixtures/baz.js');
+            const bar = fs.readFileSync("/dist/bar.js").toString();
+
+            expect(bar).toContain('/*** REQUIRES FROM autoload-modules-loader ***/');
+            expect(bar).toContain('__webpack_require__(3); // dep-b-plugin.js');
+            expect(bar).not.toContain('// dep-a-plugin-1.js');
+            expect(bar).not.toContain('// dep-a-plugin-2.js');
         });
     });
 
+    it('should not affect modules that without plugins',  () => {
+        const compiler = createCompiler({
+            baz: path.resolve(__dirname, 'fixtures/baz.js'),
+        });
+        const fs = new MemoryFileSystem();
+        compiler.outputFileSystem = fs;
+        return compile(compiler).then(() => {
+            const baz = fs.readFileSync("/dist/baz.js").toString();
+
+            expect(baz).not.toContain('/*** REQUIRES FROM autoload-modules-loader ***/');
+        });
+    });
+
+    it('should work with other loaders, e.g. handlebars-loader',  () => {
+        const compiler = createCompiler({
+            qux: path.resolve(__dirname, 'fixtures/qux.js'),
+        });
+        const fs = new MemoryFileSystem();
+        compiler.outputFileSystem = fs;
+        return compile(compiler).then(() => {
+            const qux = fs.readFileSync("/dist/qux.js").toString();
+
+            expect(qux).toContain('/*** REQUIRES FROM autoload-modules-loader ***/');
+            expect(qux).toContain('// handlebars-extras.js');
+        });
+    });
 });


### PR DESCRIPTION
In the initial commit, I added the 'require' statements at the end
of the module being required instead the file doing the requiring.
This diff changes the insertion point to be the end of the file doing
the requiring.  This matches the same semantics as webapp.

Test Plan: 
- npm test

cc: @csilvers @somewhatabstract @matchu 

TODOs:
- [x] update README.md
- [x] write tests that verify that this works when compiling .handlebars files